### PR TITLE
Timeout implementation for connections.

### DIFF
--- a/core/src/config.cpp
+++ b/core/src/config.cpp
@@ -16,7 +16,7 @@ Config::Config(const RunMode &mode, const std::string &filePath)
       general_({configYaml_["general"]["fakeUrl"].as<std::string>(),
                 configYaml_["general"]["method"].as<std::string>(),
                 configYaml_["general"]["timeWait"].as<unsigned int>(),
-                configYaml_["general"]["timeout"].as<unsigned int>(),
+                configYaml_["general"]["timeout"].as<unsigned short>(),
                 configYaml_["general"]["repeatWait"].as<unsigned short>()}),
       log_({configYaml_["log"]["logLevel"].as<std::string>(),
             configYaml_["log"]["logFile"].as<std::string>()}),

--- a/core/src/config.cpp
+++ b/core/src/config.cpp
@@ -16,6 +16,7 @@ Config::Config(const RunMode &mode, const std::string &filePath)
       general_({configYaml_["general"]["fakeUrl"].as<std::string>(),
                 configYaml_["general"]["method"].as<std::string>(),
                 configYaml_["general"]["timeWait"].as<unsigned int>(),
+                configYaml_["general"]["timeout"].as<unsigned int>(),
                 configYaml_["general"]["repeatWait"].as<unsigned short>()}),
       log_({configYaml_["log"]["logLevel"].as<std::string>(),
             configYaml_["log"]["logFile"].as<std::string>()}),
@@ -76,6 +77,7 @@ std::string Config::toString() const {
        << "   fakeUrl: " << general_.fakeUrl << "\n"
        << "   method: " << general_.method << "\n"
        << "   timeWait: " << general_.timeWait << "\n"
+       << "   timeout: " << general_.timeout << "\n"
        << "   repeatWait: " << general_.repeatWait << "\n"
        << " Log :\n"
        << "   logLevel: " << log_.level << "\n"

--- a/core/src/config.hpp
+++ b/core/src/config.hpp
@@ -18,6 +18,7 @@ private:
         std::string fakeUrl;
         std::string method;
         unsigned int timeWait;
+        unsigned int timeout;
         unsigned short repeatWait;
     };
 

--- a/core/src/config.hpp
+++ b/core/src/config.hpp
@@ -18,7 +18,7 @@ private:
         std::string fakeUrl;
         std::string method;
         unsigned int timeWait;
-        unsigned int timeout;
+        unsigned short timeout;
         unsigned short repeatWait;
     };
 

--- a/core/src/tcpclient.cpp
+++ b/core/src/tcpclient.cpp
@@ -212,7 +212,7 @@ void TCPClient::resetTimeout() {
         return;
 
     // Start/Reset the timer and cancel old handlers
-    timeout_.expires_from_now(boost::posix_time::milliseconds(config_->general().timeout));
+    timeout_.expires_from_now(boost::posix_time::seconds(config_->general().timeout));
     timeout_.async_wait(boost::bind(&TCPClient::onTimeout,
                                     shared_from_this(),
                                     boost::asio::placeholders::error));
@@ -224,15 +224,15 @@ void TCPClient::cancelTimeout() {
         timeout_.cancel();
 }
 
-void TCPClient::onTimeout(const boost::system::error_code &e) {
+void TCPClient::onTimeout(const boost::system::error_code &error) {
     // Ignore cancellation and only handle timer expiration.
-    if (e /* No Error */ || e == boost::asio::error::operation_aborted) return;
+    if (error /* No Error */ || error == boost::asio::error::operation_aborted) return;
 
     // Timeout has expired, do necessary actions
     log_->write(
             std::string("[" + to_string(uuid_) + "] [TCPClient onTimeout] [expiration] ") +
                     std::to_string(+config_->general().timeout) +
-                    " miliseconds has passed, and the timeout has expired",
+                    " seconds has passed, and the timeout has expired",
             Log::Level::DEBUG);
 
     // Stop further I/O operations

--- a/core/src/tcpclient.cpp
+++ b/core/src/tcpclient.cpp
@@ -20,7 +20,7 @@ TCPClient::TCPClient(boost::asio::io_context &io_context,
       io_context_(io_context),
       socket_(io_context),
       resolver_(io_context),
-      timer_(io_context) {}
+      timeout_(io_context) {}
 
 /*
  * Getter for the socket.
@@ -99,11 +99,14 @@ void TCPClient::doWrite(boost::asio::streambuf &buffer) {
         // Perform the write operation
         boost::system::error_code error;
         if (writeBuffer_.size() > 0) {
+            resetTimeout();
             boost::asio::write(socket_, writeBuffer_, error);
+            cancelTimeout();
             if (error) {
                 log_->write(std::string("[" + to_string(uuid_) + "] [TCPClient doWrite] [error] ") + error.message(),
                             Log::Level::DEBUG);
                 socket_.close();// Close socket on write error
+                return;
             }
         } else {
             log_->write("[" + to_string(uuid_) + "] [TCPClient doWrite] [ZERO Bytes] [DST " +
@@ -112,6 +115,7 @@ void TCPClient::doWrite(boost::asio::streambuf &buffer) {
                                 "[Bytes " + std::to_string(writeBuffer_.size()) + "] ",
                         Log::Level::DEBUG);
             socket_.close();// Close socket on write error
+            return;
         }
     } catch (std::exception &error) {
         // Log exceptions during the write operation
@@ -132,9 +136,11 @@ void TCPClient::doRead() {
         // Clear the read buffer
         readBuffer_.consume(readBuffer_.size());
         boost::system::error_code error;
+        resetTimeout();
         // Read at least 39 bytes from the socket
         boost::asio::read(socket_, readBuffer_, boost::asio::transfer_exactly(39),
                           error);
+        cancelTimeout();
         // Implement retry mechanism if data is still available
         boost::asio::steady_timer timer(io_context_);
         for (auto i = 0; i <= config_->general().repeatWait; i++) {
@@ -146,8 +152,10 @@ void TCPClient::doRead() {
                     return;
                 }
                 if (socket_.available() == 0) break;
+                resetTimeout();
                 boost::asio::read(socket_, readBuffer_,
                                   boost::asio::transfer_exactly(1), error);
+                cancelTimeout();
                 if (error == boost::asio::error::eof) {
                     log_->write("[" + to_string(uuid_) + "] [TCPClient doRead] [EOF] Connection closed by peer.",
                                 Log::Level::TRACE);
@@ -196,4 +204,37 @@ void TCPClient::doRead() {
         socket_.close();// Ensure socket closure on error
         return;         // Exit after closing the socket
     }
+}
+
+void TCPClient::resetTimeout() {
+    // indicates no timeout
+    if (!config_->general().timeout)
+        return;
+
+    // Start/Reset the timer and cancel old handlers
+    timeout_.expires_from_now(boost::posix_time::milliseconds(config_->general().timeout));
+    timeout_.async_wait(boost::bind(&TCPClient::onTimeout,
+                                    shared_from_this(),
+                                    boost::asio::placeholders::error));
+}
+
+void TCPClient::cancelTimeout() {
+    // If timeout is enabled, cancel the handlers
+    if (config_->general().timeout)
+        timeout_.cancel();
+}
+
+void TCPClient::onTimeout(const boost::system::error_code &e) {
+    // Ignore cancellation and only handle timer expiration.
+    if (e /* No Error */ || e == boost::asio::error::operation_aborted) return;
+
+    // Timeout has expired, do necessary actions
+    log_->write(
+            std::string("[" + to_string(uuid_) + "] [TCPClient onTimeout] [expiration] ") +
+                    std::to_string(+config_->general().timeout) +
+                    " miliseconds has passed, and the timeout has expired",
+            Log::Level::DEBUG);
+
+    // Stop further I/O operations
+    socket_.close();
 }

--- a/core/src/tcpclient.hpp
+++ b/core/src/tcpclient.hpp
@@ -108,6 +108,13 @@ private:
                        const std::shared_ptr<Config> &config,
                        const std::shared_ptr<Log> &log);
 
+    // If the timeout is enabled, start/reset it
+    void resetTimeout();
+    // Cancel the timeout
+    void cancelTimeout();
+    // Handler in case of a timeout expiration
+    void onTimeout(const boost::system::error_code &e);
+
     // Members
     const std::shared_ptr<Config>
             &config_;                        // Reference to the configuration object
@@ -117,7 +124,7 @@ private:
     boost::asio::streambuf writeBuffer_;     // Buffer for data to be written
     boost::asio::streambuf readBuffer_;      // Buffer for data to be read
     boost::asio::ip::tcp::resolver resolver_;// Resolver for endpoint resolution
-    boost::asio::deadline_timer timer_;      // Timer for managing timeouts
+    boost::asio::deadline_timer timeout_;    // Timer for managing timeouts
 
     // Mutex for protecting access to the socket and buffers
     mutable std::mutex mutex_;

--- a/core/src/tcpclient.hpp
+++ b/core/src/tcpclient.hpp
@@ -113,7 +113,7 @@ private:
     // Cancel the timeout
     void cancelTimeout();
     // Handler in case of a timeout expiration
-    void onTimeout(const boost::system::error_code &e);
+    void onTimeout(const boost::system::error_code &error);
 
     // Members
     const std::shared_ptr<Config>

--- a/core/src/tcpconnection.hpp
+++ b/core/src/tcpconnection.hpp
@@ -66,14 +66,22 @@ private:
                            const std::shared_ptr<Log> &log,
                            const TCPClient::pointer &client);
 
+    // If the timeout is enabled, start/reset it
+    void resetTimeout();
+    // Cancel the timeout
+    void cancelTimeout();
+    // Handler in case of a timeout expiration
+    void onTimeout(const boost::system::error_code &e);
+
     boost::asio::ip::tcp::socket socket_;  // The TCP socket for this connection
     const std::shared_ptr<Config> &config_;// Configuration settings
     const std::shared_ptr<Log> &log_;      // Logging object
     boost::asio::io_context &io_context_;  // The I/O context
     const TCPClient::pointer &client_;     // Pointer to the associated TCP client
     boost::asio::streambuf readBuffer_,
-            writeBuffer_;              // Buffers for reading and writing data
-    boost::asio::deadline_timer timer_;// Timer used for managing timeouts
+            writeBuffer_;                // Buffers for reading and writing data
+    boost::asio::deadline_timer timer_;  // Timer used for managing timeouts
+    boost::asio::deadline_timer timeout_;// Connections timeout
 
     boost::asio::strand<boost::asio::io_context::executor_type> strand_;
 

--- a/core/src/tcpconnection.hpp
+++ b/core/src/tcpconnection.hpp
@@ -71,7 +71,7 @@ private:
     // Cancel the timeout
     void cancelTimeout();
     // Handler in case of a timeout expiration
-    void onTimeout(const boost::system::error_code &e);
+    void onTimeout(const boost::system::error_code &error);
 
     boost::asio::ip::tcp::socket socket_;  // The TCP socket for this connection
     const std::shared_ptr<Config> &config_;// Configuration settings
@@ -80,7 +80,6 @@ private:
     const TCPClient::pointer &client_;     // Pointer to the associated TCP client
     boost::asio::streambuf readBuffer_,
             writeBuffer_;                // Buffers for reading and writing data
-    boost::asio::deadline_timer timer_;  // Timer used for managing timeouts
     boost::asio::deadline_timer timeout_;// Connections timeout
 
     boost::asio::strand<boost::asio::io_context::executor_type> strand_;

--- a/nipovpn/etc/nipovpn/config.yaml
+++ b/nipovpn/etc/nipovpn/config.yaml
@@ -1,5 +1,5 @@
 ---
-# This block contains general and global configucration which is in both modes
+# This block contains general and global configuration which is in both modes
 general:
   fakeUrl: "http://www.adas.com/api01"
   # method: "HEAD|GET|POST|PUT|DELETE"
@@ -7,9 +7,13 @@ general:
   #   you like to send requests from agent to server
   method: "POST"
   # timeWait: unsigned int(0-4,294,967,295)
-  # Defines the time wait between each reapeat to read from socket.
-  #   This directive will be usefull when you expect to read very long stream from socket
+  # Defines the time wait between each repeat to read from socket.
+  #   This directive will be useful when you expect to read very long stream from socket
   timeWait: 0
+  # timeout: unsigned int
+  # Defines the timeout for I/O Operation. 0 indicates no timeout.
+  #   Useful to automatically close stalled connections.
+  timeout: 0
   # repeatWait: unsigned short(1-65,635)
   # Defines the loop count which will try to repeat read from socket.
   #   Same as timeWait

--- a/nipovpn/etc/nipovpn/config.yaml
+++ b/nipovpn/etc/nipovpn/config.yaml
@@ -10,8 +10,8 @@ general:
   # Defines the time wait between each repeat to read from socket.
   #   This directive will be useful when you expect to read very long stream from socket
   timeWait: 0
-  # timeout: unsigned int
-  # Defines the timeout for I/O Operation. 0 indicates no timeout.
+  # timeout: unsigned short
+  # Defines the timeout for I/O Operation in seconds. 0 indicates no timeout.
   #   Useful to automatically close stalled connections.
   timeout: 0
   # repeatWait: unsigned short(1-65,635)


### PR DESCRIPTION
## Objective

Automatically closing a connection, which becomes stalled for some reason.
Fixes MortezaBashsiz/nipovpn#79

## Implementation Details

Before every read/write operation, a timer (`deadline_timer`) gets started/reseted, and after each successful I/O; the timer gets cancelled.  When timer's handlers called ,in case of an expiration, it closes associated socket with the connection; by doing so, any blocking I/O on respected socket will be interrupted.

This patch only addresses *TCPConnection* and *TCPClient* classes' read and write methods. The underlying implementation is identical for both classes.

## Test

For testing, I did following scenarios while `timeout` is specified:

- Grabbing `www.google.com` using `curl` to check to ensure no data transfer issue.
- `telnet` to agent's socket and waiting to be closed by timeout.
- Using a simple python TCP socket as a destination server and never sending any data. Which caused the connection to be timeout-ed.

My tests are not addressing every block of read and write code, therefore this patch should be tested further to ensure stability. 

## About the diffs

Timeout configuration is identical to `timeWait` and uses similar value range.  
I have implemented three main method to handle the timer: `resetTimeout`, `cancelTimeout` and `onTimeout`. 
And few other minor changes.



Please, let me know of any issue/suggestion :)



