### PR TITLE
feat: add nix flake support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Build from source for [Linux](guides/BuildLinux.md)
 
 Build from source for [Linux](guides/InstallTermux.md)
 
+## Nix
+
+For development, building, installation, and NixOS integration, see the [Nix Guide](guides/Nix.md).
 
 ## Run
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
       pkgs = nixpkgs.legacyPackages.${system};
       nipovpn = pkgs.stdenv.mkDerivation {
         pname = "nipovpn";
-        version = "1.1.56";
+        version = "1.1.57";
         src = self;
 
         nativeBuildInputs = with pkgs; [cmake];

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,72 @@
+{
+  description = "NipoVPN - Powerful HTTP proxy";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }:
+    flake-utils.lib.eachSystem ["x86_64-linux" "aarch64-linux"] (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+      nipovpn = pkgs.stdenv.mkDerivation {
+        pname = "nipovpn";
+        version = "1.1.56";
+        src = self;
+
+        nativeBuildInputs = with pkgs; [cmake];
+        buildInputs = with pkgs; [boost yaml-cpp openssl];
+
+        cmakeFlags = ["-DCMAKE_BUILD_TYPE=Release"];
+
+        installPhase = ''
+          runHook preInstall
+          mkdir -p $out/bin $out/etc/nipovpn
+          cp core/nipovpn $out/bin/nipovpn
+          cp -r $src/nipovpn/etc/nipovpn/. $out/etc/nipovpn/
+          runHook postInstall
+        '';
+
+        meta = with pkgs.lib; {
+          description = "Powerful HTTP proxy with traffic obfuscation";
+          homepage = "https://github.com/MortezaBashsiz/nipovpn";
+          license = licenses.gpl3Plus;
+          platforms = platforms.linux;
+          mainProgram = "nipovpn";
+        };
+      };
+    in {
+      packages.default = nipovpn;
+      packages.nipovpn = nipovpn;
+
+      devShells.default = pkgs.mkShell {
+        buildInputs = with pkgs; [
+          cmake
+          ninja
+          boost
+          yaml-cpp
+          openssl
+          clang-tools
+          gdb
+          valgrind
+        ];
+
+        shellHook = ''
+          echo "NipoVPN dev environment ready"
+          echo ""
+          echo "You can build using either Make or Ninja:"
+          echo "  Standard (Make):"
+          echo "    cmake -B build -DCMAKE_BUILD_TYPE=Debug"
+          echo "    cmake --build build -j\$(nproc)"
+          echo ""
+          echo "  Fast (Ninja):"
+          echo "    cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug"
+          echo "    cmake --build build -j\$(nproc)"
+        '';
+      };
+    });
+}

--- a/guides/Nix.md
+++ b/guides/Nix.md
@@ -1,0 +1,84 @@
+## Nix Guide
+
+**Note:** Nix Flakes are an experimental feature and must be enabled before using any of the commands in this guide.
+
+### Enable Flakes
+
+* **NixOS:** Follow the instructions in the NixOS & Flakes Book:
+
+  [Enabling NixOS with Flakes](https://nixos-and-flakes.thiscute.world/nixos-with-flakes/nixos-with-flakes-enabled?utm_source=chatgpt.com#enable-nix-flakes)
+
+* **Non-NixOS systems:** Add the following to `~/.config/nix/nix.conf` (or `/etc/nix/nix.conf`):
+
+```bash
+experimental-features = nix-command flakes
+```
+
+## Installation
+
+### Install into your Nix profile
+
+```bash
+nix profile install github:MortezaBashsiz/nipovpn
+```
+
+### NixOS (system-wide installation)
+
+Add the flake as an input in your system `flake.nix`:
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nipovpn.url = "github:MortezaBashsiz/nipovpn";
+  };
+
+  outputs = { self, nixpkgs, nipovpn, ... }: {
+    nixosConfigurations.yourhostname = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux"; # or "aarch64-linux"
+
+      modules = [
+        ./configuration.nix
+        {
+          environment.systemPackages = [
+            nipovpn.packages.${pkgs.system}.default
+          ];
+        }
+      ];
+    };
+  };
+}
+```
+
+## Building
+
+### Manual Build (without Nix)
+
+For traditional builds on Linux, please refer to [`BuildLinux.md`](./BuildLinux.md).
+
+### Build with Nix
+
+From the repository root:
+
+```bash
+nix build
+```
+
+Or directly from GitHub without cloning:
+
+```bash
+nix build github:MortezaBashsiz/nipovpn
+```
+
+## Development
+
+Enter the development shell with all dependencies pre-configured:
+
+```bash
+git clone https://github.com/MortezaBashsiz/nipovpn.git
+cd nipovpn
+
+nix develop
+```
+
+If the command completes successfully, the development environment is ready to use.


### PR DESCRIPTION
Added full Nix Flake support including build derivation, devShell and documentation.

#### Changes
- Added `flake.nix` and `flake.lock`
- Added comprehensive `guides/Nix.md`
- Synced version with current dev branch (1.1.57)

#### For test
```bash
nix develop    # enter dev environment
nix build      # build the project
nix run        # run nipovpn